### PR TITLE
[chore] Remove .vscode from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 /RUNNING_PID
 /.bloop/
 /.metals/
+/.vscode/


### PR DESCRIPTION
## Why
The `.vscode` directory contains settings specific to Visual Studio Code, which are not relevant for team members using different IDEs. To avoid cluttering the repository with IDE-specific configurations and to prevent potential conflicts, we should exclude this directory from version control.

## What I do
- Added the `.vscode/` directory to the `.gitignore` file to prevent it from being tracked by Git.
- Removed the `.vscode/` directory from version control.