### PR TITLE
[fix] Update syntax for ExamResultTable and ExamTable for Scala 3.4 a…

### DIFF
--- a/app/infrastructure/db/table/ExamResultTable.scala
+++ b/app/infrastructure/db/table/ExamResultTable.scala
@@ -7,12 +7,10 @@ import slick.jdbc.MySQLProfile.api._
 import dto.infrastructure.examResult.entity.ExamResultDto
 import java.time.ZonedDateTime
 
-// ExamResultテーブルの定義
 class ExamResultTable(tag: Tag)(implicit val profile: JdbcProfile)
     extends Table[ExamResultDto](tag, "exam_results") {
   import profile.api._
 
-  // テーブルの列定義
   def examResultId: Rep[String] = column[String]("exam_result_id", O.PrimaryKey)
   def examId: Rep[String] = column[String]("exam_id", NotNull)
   def score: Rep[Int] = column[Int]("score", NotNull)
@@ -31,10 +29,9 @@ class ExamResultTable(tag: Tag)(implicit val profile: JdbcProfile)
     evaluation,
     createdAt,
     updatedAt
-  ) <> ((ExamResultDto.apply _).tupled, ExamResultDto.unapply)
+  ).mapTo[ExamResultDto]
 }
 
-// ExamResultTableオブジェクト
 object ExamResultTable {
   val examResults = TableQuery[ExamResultTable]
 }

--- a/app/infrastructure/db/table/ExamTable.scala
+++ b/app/infrastructure/db/table/ExamTable.scala
@@ -28,7 +28,7 @@ class ExamTable(tag: Tag)(implicit val profile: JdbcProfile)
     evaluationStatus,
     createdAt,
     updatedAt
-  ) <> ((ExamDto.apply _).tupled, ExamDto.unapply)
+  ).mapTo[ExamDto]
 }
 
 object ExamTable {


### PR DESCRIPTION
## Why
The current `ExamResultTable` and `ExamTable` implementations use a deprecated function syntax (`apply _`) that is no longer supported in Scala 3.4. To ensure compatibility and future-proof the code, we need to update this syntax. Additionally, there are unnecessary comment lines that clutter the codebase and should be removed for better readability.

## What I do
- Replaced the deprecated `apply _` syntax in `ExamResultTable` and `ExamTable` with the new `.mapTo[DtoClass]` syntax.
- Removed unnecessary comment lines in `ExamResultTable` and `ExamTable` to clean up the code.