### PR TITLE
[Refactor] Refactor saveExamResult method in ExamResultUsecase to use…

### DIFF
--- a/app/usecases/examResult/ExamResultUsecase.scala
+++ b/app/usecases/examResult/ExamResultUsecase.scala
@@ -36,18 +36,19 @@ class ExamResultUsecase @Inject() (
       score: Score,
       studentId: StudentId
   ): Future[Either[String, ExamResult]] = {
-    val examResultId = ulidGenerator.generate()
-    val examResult = ExamResult(
-      ExamResultId.create(examResultId),
-      examId,
-      score,
-      studentId,
-      Evaluation.NotEvaluated,
-      CreatedAt(ZonedDateTime.now()),
-      UpdatedAt(ZonedDateTime.now())
-    )
-
-    examResultRepository.save(examResult)
+    (for {
+      examResultId <- EitherT.rightT[Future, String](ulidGenerator.generate())
+      examResult = ExamResult(
+        ExamResultId.create(examResultId),
+        examId,
+        score,
+        studentId,
+        Evaluation.NotEvaluated,
+        CreatedAt(ZonedDateTime.now()),
+        UpdatedAt(ZonedDateTime.now())
+      )
+      savedExamResult <- EitherT(examResultRepository.save(examResult))
+    } yield savedExamResult).value
   }
 
   def findById(


### PR DESCRIPTION
## Why
This PR aims to refactor the `saveExamResult` method in the `ExamResultUsecase` class. The goal is to enhance the readability and maintainability of the code by using `EitherT` and for-comprehension for more linear error handling and code structure.

## What I do
- Refactored the `saveExamResult` method to use `EitherT`.
- Implemented for-comprehension to achieve a linear and more readable code flow.