### PR TITLE
[feat] The scheduler was implemented and the evaluation period determ…

### DIFF
--- a/app/domain/evaluationPeriodProvider/impl/WeeklyEvaluationPeriodProvider.scala
+++ b/app/domain/evaluationPeriodProvider/impl/WeeklyEvaluationPeriodProvider.scala
@@ -8,10 +8,17 @@ import java.time.DayOfWeek
 class WeeklyEvaluationPeriodProvider extends EvaluationPeriodProvider {
   override def getEvaluationPeriod: (ZonedDateTime, ZonedDateTime) = {
     val now = ZonedDateTime.now()
-    val startOfWeek = now.toLocalDate
+    val startOfWeek = now
+      .minusWeeks(1)
+      .toLocalDate
       .`with`(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
       .atStartOfDay(now.getZone)
     val endOfWeek = now
+      .minusWeeks(1)
+      .toLocalDate
+      .`with`(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+      .atTime(23, 59, 59, 999999999)
+      .atZone(now.getZone)
     (startOfWeek, endOfWeek)
   }
 }

--- a/app/scheduler/JobScheduler.scala
+++ b/app/scheduler/JobScheduler.scala
@@ -1,0 +1,43 @@
+package scheduler
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import org.apache.pekko.actor.ActorSystem
+import usecases.examResult.ExamResultUsecase
+import java.time.ZonedDateTime
+
+@Singleton
+class JobScheduler @Inject() (
+    actorSystem: ActorSystem,
+    examResultUsecase: ExamResultUsecase
+)(implicit ec: ExecutionContext) {
+
+  private def calculateInitialDelay(): FiniteDuration = {
+    val now = ZonedDateTime.now()
+    val nextSunday = now
+      .`with`(
+        java.time.temporal.TemporalAdjusters
+          .nextOrSame(java.time.DayOfWeek.SUNDAY)
+      )
+      .withHour(24)
+      .withMinute(0)
+      .withSecond(0)
+    val duration = java.time.Duration.between(now, nextSunday)
+    FiniteDuration(duration.toMillis, MILLISECONDS)
+  }
+
+  private val period: FiniteDuration = FiniteDuration(7, DAYS)
+
+  actorSystem.scheduler.scheduleWithFixedDelay(
+    calculateInitialDelay(),
+    period
+  )(new Runnable {
+    def run(): Unit = {
+      examResultUsecase.evaluateResults.map {
+        case Right(_)    => println("Scheduled job completed successfully.")
+        case Left(error) => println(s"Scheduled job failed with error: $error")
+      }
+    }
+  })
+}

--- a/app/usecases/examResult/ExamResultUsecase.scala
+++ b/app/usecases/examResult/ExamResultUsecase.scala
@@ -57,7 +57,7 @@ class ExamResultUsecase @Inject() (
     examResultRepository.findById(examId)
   }
 
-  def evaluateResults: Future[Unit] = {
+  def evaluateResults: Future[Either[String, Unit]] = {
     (for {
       (startDate, endDate) <- EitherT.pure[Future, String](
         evaluationPeriodProvider.getEvaluationPeriod
@@ -87,9 +87,6 @@ class ExamResultUsecase @Inject() (
           }
         })
         .map(_.collect { case Right(value) => value })
-    } yield ()).value.map {
-      case Right(_)    => ()
-      case Left(error) => throw new Exception(error)
-    }
+    } yield ()).value
   }
 }


### PR DESCRIPTION
## Why
We wanted the `ExamResult` to be automatically evaluated at the end of every Sunday (Monday at midnight).

## What I did
- Updated `WeeklyEvaluationPeriodProvider` to calculate the evaluation period from the start of the previous Monday to the end of the previous Sunday.
- Created `JobScheduler` to schedule the `evaluateResults` method to run every week.
- Fixed the return value of the `evaluateResults` method of the `ExamResultUsecase` class to `Future[Either[String, Unit]]`.