### PR TITLE
[feat] Add Docker setup for development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:11-jdk-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y curl gnupg && \
+    echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
+    curl -sL "https://keybase.io/sbt/pgp_keys.asc" | apt-key add && \
+    apt-get update && apt-get install -y sbt
+
+COPY . .
+
+RUN sbt compile stage
+
+CMD ["sbt", "run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+      MYSQL_DATABASE: exam_manager
+      MYSQL_USER: your_username
+      MYSQL_PASSWORD: your_password
+    ports:
+      - "3306:3306"
+    volumes:
+      - exam_manager_db_data:/var/lib/mysql
+
+  app:
+    build: .
+    ports:
+      - "9000:9000"
+    depends_on:
+      - db
+    environment:
+      DB_URL: "jdbc:mysql://db:3306/exam_manager"
+      DB_USER: "your_username"
+      DB_PASSWORD: "your_password"
+    command: sbt run
+
+volumes:
+  db_data:


### PR DESCRIPTION
# What I did
- Added a Dockerfile to set up the application container with sbt and the appropriate JDK, ensuring a consistent development environment.
- Created a docker-compose.yml file to define and orchestrate services, including the application and MySQL database, for easier and consistent management of the development environment.
- Configured environment variables and volumes within docker-compose.yml to ensure seamless interaction between the application and the database, and to persist data across container restarts.
- This setup allows developers to quickly spin up a development environment with Docker, maintaining consistency across different machines and reducing the risk of environment-specific issues.

# Why I did
- To provide a standardized and reproducible development environment using Docker, ensuring that all developers work with the same configurations.
- To simplify the setup process for the development environment, reducing the time required to get started on new machines.
- To ensure that the application and its dependencies, such as the MySQL database, are correctly configured and interact properly without manual setup.
- To improve the development workflow by enabling easy containerized management of services, which helps in maintaining consistency between the development and production environments.