### PR TITLE
[chore] Update Dockerfile to use Amazon Corretto 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim
+FROM amazoncorretto:11
 
 WORKDIR /app
 


### PR DESCRIPTION
# What I did
Updated the Dockerfile to use Amazon Corretto 11 as the base image instead of OpenJDK. This change aligns the Docker environment with our project requirements, ensuring consistency with the JDK version used in development.

# Why I did
Our project mandates the use of Amazon Corretto 11 as the JDK, which is the latest LTS version we are targeting. This update ensures that our Docker environment reflects the same JDK version, maintaining consistency across local development and production environments.