### PR TITLE
[refactor] Append 'OnDb' to repository implementation classes to clarify usage of database technology in class names

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -4,8 +4,8 @@ import java.time.Clock
 import play.api.inject.{ApplicationLifecycle, Binding}
 import play.api.{Configuration, Environment}
 import infrastructure.db.repositories.{
-  ExamResultRepositoryImpl,
-  ExamRepositoryImpl
+  ExamResultRepositoryImplOnDb,
+  ExamRepositoryImplOnDb
 }
 import usecases.examResult.repository.ExamResultRepository
 import usecases.exam.repository.ExamRepository
@@ -56,10 +56,10 @@ class Module(environment: Environment, configuration: Configuration)
 
   override def configure(): Unit = {
     bind(classOf[ExamResultRepository])
-      .to(classOf[ExamResultRepositoryImpl])
+      .to(classOf[ExamResultRepositoryImplOnDb])
       .asEagerSingleton()
     bind(classOf[ExamRepository])
-      .to(classOf[ExamRepositoryImpl])
+      .to(classOf[ExamRepositoryImplOnDb])
       .asEagerSingleton()
     bind(classOf[UlidGenerator])
       .to(classOf[UlidGeneratorImpl])

--- a/app/infrastructure/db/repositories/ExamResultRepositoryImplOnDb.scala
+++ b/app/infrastructure/db/repositories/ExamResultRepositoryImplOnDb.scala
@@ -1,35 +1,38 @@
 package infrastructure.db.repositories
 
 import javax.inject.{Inject, Singleton}
-import domain.exam.entity.Exam
-import dto.infrastructure.exam.entity.ExamDto
 import infrastructure.db.DatabaseConfig
-import infrastructure.db.table.ExamTable
-import usecases.exam.repository.ExamRepository
+import infrastructure.db.table.ExamResultTable
+import scala.concurrent.{ExecutionContext, Future}
+import usecases.examResult.repository.ExamResultRepository
+import domain.examResult.entity.ExamResult
+import domain.exam.valueObject._
+import dto.infrastructure.examResult.entity.ExamResultDto
 import utils.Retry
-import scala.concurrent.{Future, ExecutionContext}
 import scala.concurrent.duration._
 import org.apache.pekko.actor.Scheduler
 import java.sql.SQLTransientConnectionException
 import java.time.ZonedDateTime
-import domain.exam.valueObject.ExamId
+import domain.examResult.valueObject.ExamResultId
 
 @Singleton
-class ExamRepositoryImpl @Inject() (
+class ExamResultRepositoryImplOnDb @Inject() (
     dbConfig: DatabaseConfig,
     scheduler: Scheduler
 )(implicit
     ec: ExecutionContext
-) extends ExamRepository {
+) extends ExamResultRepository {
   import dbConfig._
   import profile.api._
 
-  override def save(exam: Exam): Future[Either[String, Exam]] = {
-    val dto = ExamDto.fromDomain(exam)
-    val query = ExamTable.exams += dto
+  override def save(
+      examResult: ExamResult
+  ): Future[Either[String, ExamResult]] = {
+    val dto = ExamResultDto.fromDomain(examResult)
+    val query = ExamResultTable.examResults += dto
     Retry
       .withRetry(run(query), 3, 1.second)(ec, scheduler)
-      .map(_ => Right(exam))
+      .map(_ => Right(examResult))
       .recover {
         case ex: SQLTransientConnectionException =>
           Left("Database connection error")
@@ -38,19 +41,19 @@ class ExamRepositoryImpl @Inject() (
   }
 
   override def findById(
-      examId: ExamId
-  ): Future[Either[String, Option[Exam]]] = {
-    val query = ExamTable.exams
-      .filter(_.examId === examId.value)
+      examResultId: ExamResultId
+  ): Future[Either[String, Option[ExamResult]]] = {
+    val query = ExamResultTable.examResults
+      .filter(_.examResultId === examResultId.value)
       .result
       .headOption
     Retry
       .withRetry(run(query), 3, 1.second)(ec, scheduler)
       .map {
         case Some(dto) =>
-          ExamDto.toDomain(dto) match {
-            case Right(exam) => Right(Some(exam))
-            case Left(error) => Left(error)
+          ExamResultDto.toDomain(dto) match {
+            case Right(examResult) => Right(Some(examResult))
+            case Left(error)       => Left(error)
           }
         case None => Right(None)
       }
@@ -61,26 +64,21 @@ class ExamRepositoryImpl @Inject() (
       }
   }
 
-  override def findByDueDate(
-      startDate: ZonedDateTime,
-      endDate: ZonedDateTime
-  ): Future[Either[String, Seq[Exam]]] = {
-    val query = ExamTable.exams
-      .filter(exam => exam.dueDate >= startDate && exam.dueDate <= endDate)
+  override def findByExamId(
+      examId: ExamId
+  ): Future[Either[String, Seq[ExamResult]]] = {
+    val query = ExamResultTable.examResults
+      .filter(_.examId === examId.value)
       .result
-
     Retry
       .withRetry(run(query), 3, 1.second)(ec, scheduler)
       .map { dtos =>
-        val exams = dtos.map(ExamDto.toDomain)
-        val (errors, validExams) = exams.partitionMap(identity)
-
+        val examResults = dtos.map(ExamResultDto.toDomain)
+        val errors = examResults.collect { case Left(error) => error }
         if (errors.nonEmpty) {
           Left(errors.mkString(", "))
-        } else if (validExams.isEmpty) {
-          Left("No exams found for the given period")
         } else {
-          Right(validExams)
+          Right(examResults.collect { case Right(examResult) => examResult })
         }
       }
       .recover {
@@ -90,13 +88,16 @@ class ExamRepositoryImpl @Inject() (
       }
   }
 
-  override def update(exam: Exam): Future[Either[String, Exam]] = {
-    val dto = ExamDto.fromDomain(exam)
-    val query =
-      ExamTable.exams.filter(_.examId === dto.examIdDto.value).update(dto)
+  override def update(
+      examResult: ExamResult
+  ): Future[Either[String, ExamResult]] = {
+    val dto = ExamResultDto.fromDomain(examResult)
+    val query = ExamResultTable.examResults
+      .filter(_.examResultId === dto.examResultId)
+      .update(dto)
     Retry
       .withRetry(run(query), 3, 1.second)(ec, scheduler)
-      .map(_ => Right(exam))
+      .map(_ => Right(examResult))
       .recover {
         case ex: SQLTransientConnectionException =>
           Left("Database connection error")

--- a/test/integration/controllers/ExamResultControllerIntegrationSpec.scala
+++ b/test/integration/controllers/ExamResultControllerIntegrationSpec.scala
@@ -37,8 +37,8 @@ import usecases.exam.logic.examUpdater.impl.ExamUpdaterImpl
 import usecases.exam.logic.examUpdater.`trait`.ExamUpdater
 import infrastructure.libs.UlidGeneratorImpl
 import infrastructure.db.repositories.{
-  ExamResultRepositoryImpl,
-  ExamRepositoryImpl
+  ExamResultRepositoryImplOnDb,
+  ExamRepositoryImplOnDb
 }
 import infrastructure.db.DatabaseConfig
 import infrastructure.db.table.ExamResultTable
@@ -73,8 +73,8 @@ class ExamResultControllerIntegrationSpec
     .overrides(
       bind[SystemClock].toInstance(mockSystemClock),
       bind[UlidGenerator].toInstance(mockUlidGenerator),
-      bind[ExamResultRepository].to[ExamResultRepositoryImpl],
-      bind[ExamRepository].to[ExamRepositoryImpl],
+      bind[ExamResultRepository].to[ExamResultRepositoryImplOnDb],
+      bind[ExamRepository].to[ExamRepositoryImplOnDb],
       bind[Evaluator].to[QuartileEvaluatorImpl],
       bind[ExamResultUpdater].to[ExamResultUpdaterImpl],
       bind[ExamUpdater].to[ExamUpdaterImpl],

--- a/test/integration/scheduler/JobSchedulerIntegrationSpec.scala
+++ b/test/integration/scheduler/JobSchedulerIntegrationSpec.scala
@@ -33,8 +33,8 @@ import usecases.examResult.logic.examResultUpdater.impl.ExamResultUpdaterImpl
 import usecases.exam.logic.examUpdater.`trait`.ExamUpdater
 import usecases.exam.logic.examUpdater.impl.ExamUpdaterImpl
 import infrastructure.db.table.{ExamTable, ExamResultTable}
-import infrastructure.db.repositories.ExamRepositoryImpl
-import infrastructure.db.repositories.ExamResultRepositoryImpl
+import infrastructure.db.repositories.ExamRepositoryImplOnDb
+import infrastructure.db.repositories.ExamResultRepositoryImplOnDb
 import infrastructure.db.DatabaseConfig
 import utils.CustomPatience
 import utils.{SystemClock, UlidGenerator}
@@ -94,9 +94,9 @@ class JobSchedulerIntegrationSpec
 
   "JobScheduler" should {
     "execute the scheduled job immediately in test mode" in {
-      val examRepository = app.injector.instanceOf[ExamRepositoryImpl]
+      val examRepository = app.injector.instanceOf[ExamRepositoryImplOnDb]
       val examResultRepository =
-        app.injector.instanceOf[ExamResultRepositoryImpl]
+        app.injector.instanceOf[ExamResultRepositoryImplOnDb]
       val actorSystem = app.injector.instanceOf[ActorSystem]
 
       val now = ZonedDateTime.parse("2024-07-22T00:00:00+09:00[Asia/Tokyo]")

--- a/test/unit/infrastructure/db/repository/ExamRepositoryImplOnDbSpec.scala
+++ b/test/unit/infrastructure/db/repository/ExamRepositoryImplOnDbSpec.scala
@@ -19,7 +19,7 @@ import domain.exam.entity.Exam
 import domain.exam.valueObject._
 import domain.utils.dateTime.{CreatedAt, UpdatedAt}
 import infrastructure.db.DatabaseConfig
-import infrastructure.db.repositories.ExamRepositoryImpl
+import infrastructure.db.repositories.ExamRepositoryImplOnDb
 import infrastructure.db.table.ExamTable
 import dto.infrastructure.exam.entity.ExamDto
 import utils.CustomPatience
@@ -31,7 +31,7 @@ import java.sql.SQLTransientConnectionException
 import slick.jdbc.H2Profile.api._
 import slick.jdbc.JdbcProfile
 
-class ExamRepositoryImplSpec
+class ExamRepositoryImplOnDbSpec
     extends PlaySpec
     with Matchers
     with ScalaFutures
@@ -48,7 +48,7 @@ class ExamRepositoryImplSpec
 
   val dbConfig = app.injector.instanceOf[DatabaseConfig]
   val mockScheduler = mock(classOf[Scheduler])
-  val repository = new ExamRepositoryImpl(dbConfig, mockScheduler)
+  val repository = new ExamRepositoryImplOnDb(dbConfig, mockScheduler)
 
   val examTable = TableQuery[ExamTable]
 
@@ -67,7 +67,7 @@ class ExamRepositoryImplSpec
     super.beforeEach()
   }
 
-  "ExamRepositoryImpl#save" should {
+  "ExamRepositoryImplOnDb#save" should {
     "return a saved Exam when given valid Exam as input" in {
       val exam = Exam(
         ExamId("exam-id"),
@@ -104,7 +104,7 @@ class ExamRepositoryImplSpec
     }
   }
 
-  "ExamRepositoryImpl#findById" should {
+  "ExamRepositoryImplOnDb#findById" should {
     "return an Exam when given a valid ExamId" in {
       val exam = Exam(
         ExamId("exam-id"),
@@ -157,7 +157,7 @@ class ExamRepositoryImplSpec
     }
   }
 
-  "ExamRepositoryImpl#findByDueDate" should {
+  "ExamRepositoryImplOnDb#findByDueDate" should {
     "return exams within the date range as input" in {
       val startDate = ZonedDateTime.now().minusDays(10)
       val endDate = ZonedDateTime.now()
@@ -225,7 +225,7 @@ class ExamRepositoryImplSpec
     }
   }
 
-  "ExamRepositoryImpl#update" should {
+  "ExamRepositoryImplOnDb#update" should {
     "return a updated Exam when given valid Exam as input" in {
       val exam = Exam(
         ExamId("exam-id"),

--- a/test/unit/infrastructure/db/repository/ExamResultRepositoryImplOnDbSpec.scala
+++ b/test/unit/infrastructure/db/repository/ExamResultRepositoryImplOnDbSpec.scala
@@ -19,7 +19,7 @@ import domain.utils.dateTime.{CreatedAt, UpdatedAt}
 import domain.examResult.valueObject._
 import domain.exam.valueObject._
 import infrastructure.db.DatabaseConfig
-import infrastructure.db.repositories.ExamResultRepositoryImpl
+import infrastructure.db.repositories.ExamResultRepositoryImplOnDb
 import infrastructure.db.table.ExamResultTable
 import dto.infrastructure.examResult.entity.ExamResultDto
 import utils.CustomPatience
@@ -30,7 +30,7 @@ import java.time.ZonedDateTime
 import java.sql.SQLTransientConnectionException
 import slick.jdbc.H2Profile.api._
 
-class ExamResultRepositoryImplSpec
+class ExamResultRepositoryImplOnDbSpec
     extends AnyWordSpec
     with Matchers
     with ScalaFutures
@@ -48,7 +48,7 @@ class ExamResultRepositoryImplSpec
 
   val dbConfig = app.injector.instanceOf[DatabaseConfig]
   val mockScheduler = mock[Scheduler]
-  val repository = new ExamResultRepositoryImpl(dbConfig, mockScheduler)
+  val repository = new ExamResultRepositoryImplOnDb(dbConfig, mockScheduler)
 
   val examResultTable = TableQuery[ExamResultTable]
 
@@ -67,7 +67,7 @@ class ExamResultRepositoryImplSpec
     super.beforeEach()
   }
 
-  "ExamResultRepositoryImpl#save" should {
+  "ExamResultRepositoryImplOnDb#save" should {
     "return a saved Exam when given valid ExamResult as input" in {
       val examResult = ExamResult(
         ExamResultId("exam-result-id"),
@@ -106,7 +106,7 @@ class ExamResultRepositoryImplSpec
     }
   }
 
-  "ExamResultRepositoryImpl#findById" should {
+  "ExamResultRepositoryImplOnDb#findById" should {
     "return a ExamResult when given corresponding ExamResultId as input" in {
       val examResultDto = ExamResultDto(
         "examResult-id",
@@ -139,7 +139,7 @@ class ExamResultRepositoryImplSpec
     }
   }
 
-  "ExamResultRepositoryImpl#findByExamId" should {
+  "ExamResultRepositoryImplOnDb#findByExamId" should {
     "return some ExamResult when given corresponding ExamId as input" in {
       val examResultDto = ExamResultDto(
         "exam-result-id",
@@ -172,7 +172,7 @@ class ExamResultRepositoryImplSpec
     }
   }
 
-  "ExamResultRepositoryImpl#update" should {
+  "ExamResultRepositoryImplOnDb#update" should {
     "return the updated ExamResult when given valid ExamResult as input" in {
       val examResult = ExamResult(
         ExamResultId("exam-result-id"),


### PR DESCRIPTION
# What I did
I added 'OnDb' to the names of Infrastructure layer implementation classes that utilize a database.

# Why I did
To ensure that the technology used is clear from the class names in the Infrastructure layer, it was necessary to add 'OnDb' to the relevant classes.