### PR TITLE
[fix] Ensure consistent date parsing results across different environments by adjusting exception handling

### DIFF
--- a/app/dto/utils/dateTime/dateTimeConverter/impl/DateTimeConverterImpl.scala
+++ b/app/dto/utils/dateTime/dateTimeConverter/impl/DateTimeConverterImpl.scala
@@ -10,10 +10,14 @@ class DateTimeConverterImpl extends DateTimeConverter {
   override def stringToZonedDateTime(
       dateTimeString: String
   ): Either[String, ZonedDateTime] = {
-    if (Try(Instant.parse(dateTimeString)).isSuccess) {
-      Left("Invalid input. Error: Instant format is not allowed.")
-    } else if (Try(OffsetDateTime.parse(dateTimeString)).isSuccess) {
-      Left("Invalid input. Error: OffsetDateTime format is not allowed.")
+    if (
+      Try(OffsetDateTime.parse(dateTimeString)).isSuccess || Try(
+        Instant.parse(dateTimeString)
+      ).isSuccess
+    ) {
+      Left(
+        "Invalid input. Error: OffsetDateTime or Instant format is not allowed."
+      )
     } else {
       Try(ZonedDateTime.parse(dateTimeString)).toEither.left.map(e =>
         s"Invalid input. Error: ${e.getMessage}"

--- a/test/unit/dto/utils/dateTime/dateTimeConverter/impl/DateTimeConverterImplSpec.scala
+++ b/test/unit/dto/utils/dateTime/dateTimeConverter/impl/DateTimeConverterImplSpec.scala
@@ -89,7 +89,7 @@ class DateTimeConverterImplSpec
       result mustBe a[Left[String, ZonedDateTime]]
       result match {
         case Left(error) =>
-          error mustBe ("Invalid input. Error: OffsetDateTime format is not allowed.")
+          error mustBe ("Invalid input. Error: OffsetDateTime or Instant format is not allowed.")
         case _ => fail("Expected Left but got Right")
       }
     }
@@ -102,7 +102,7 @@ class DateTimeConverterImplSpec
       result match {
         case Left(error) =>
           error mustBe (
-            "Invalid input. Error: Instant format is not allowed."
+            "Invalid input. Error: OffsetDateTime or Instant format is not allowed."
           )
         case _ => fail("Expected Left but got Right")
       }


### PR DESCRIPTION
# What I did
- Combined the exception handling for OffsetDateTime and Instant formats since they cannot be distinguished reliably. This ensures that these formats are identified and processed together before attempting to parse ZonedDateTime.
- Updated the corresponding test cases to verify the changes and ensure that they produce consistent results on both Windows and WSL2 (Ubuntu).

# Why I did
- In the current implementation, OffsetDateTime and Instant formats were not being correctly distinguished, leading to inconsistent results depending on the environment.
- This inconsistency caused certain date-time strings to be misinterpreted, especially when running the tests in WSL2 (Ubuntu).
- The refactor ensures that date parsing behaves consistently across all environments, improving the reliability of the application.