### PR TITLE
[refactor] Reorganize containers into three for clearer role separation

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,38 +1,18 @@
-services:
-  db:
-    environment:
-      MYSQL_DATABASE: exam_manager
-      MYSQL_PASSWORD: your_password
-      MYSQL_ROOT_PASSWORD: root_password
-      MYSQL_USER: your_username
-    image: mysql:8.0
-    ports:
-      - published: 3306
-        target: 3306
-    volumes:
-      - exam_manager_db_data:/var/lib/mysql:rw
-
-  app:
-    build:
-      context: ..
-      dockerfile: .devcontainer/Dockerfile
-      args:
-        USERNAME: ${USER}
-    command: sleep infinity
-    depends_on:
-      db:
-        condition: service_started
-    environment:
-      DB_PASSWORD: your_password
-      DB_URL: jdbc:mysql://db:3306/exam_manager
-      DB_USER: your_username
-    ports:
-      - published: 9000
-        target: 9000
-    volumes:
-      # Adjust the path below to match the location where you cloned the application repository
-      - ${HOME}/Development/exam-manager:/workspaces/exam-manager:cached
-
 version: '3.9'
-volumes:
-  exam_manager_db_data: {}
+services:
+    app:
+        build:
+            context: ..
+            dockerfile: .devcontainer/Dockerfile
+            args:
+                USERNAME: ${USER}
+        command: sleep infinity
+        environment:
+            DB_PASSWORD: your_password
+            DB_URL: jdbc:mysql://db:3306/exam_manager
+            DB_USER: your_username
+        ports:
+            - "9020:9000"
+        volumes:
+            # Adjust the path below to match the location where you cloned the application repository
+            - ${HOME}/Development/exam-manager:/workspaces/exam-manager:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,28 @@
+version: '3.9'
 services:
-  db:
-    image: mysql:8.0
-    environment:
-      MYSQL_ROOT_PASSWORD: root_password
-      MYSQL_DATABASE: exam_manager
-      MYSQL_USER: your_username
-      MYSQL_PASSWORD: your_password
-    ports:
-      - "3306:3306"
-    volumes:
-      - exam_manager_db_data:/var/lib/mysql
+    db:
+        image: mysql:8.0
+        environment:
+            MYSQL_ROOT_PASSWORD: root_password
+            MYSQL_DATABASE: exam_manager
+            MYSQL_USER: your_username
+            MYSQL_PASSWORD: your_password
+        ports:
+            - "3306:3306"
+        volumes:
+            - exam_manager_db_data_prod:/var/lib/mysql
 
-  app:
-    build: .
-    ports:
-      - "9000:9000"
-    depends_on:
-      - db
-    environment:
-      DB_URL: "jdbc:mysql://db:3306/exam_manager"
-      DB_USER: "your_username"
-      DB_PASSWORD: "your_password"
-    command: sbt run
+    app:
+        build: .
+        command: sbt run
+        environment:
+            DB_URL: "jdbc:mysql://db:3306/exam_manager"
+            DB_USER: "your_username"
+            DB_PASSWORD: "your_password"
+        ports:
+            - "9000:9000"
+        depends_on:
+            - db
 
 volumes:
-  exam_manager_db_data:
+    exam_manager_db_data_prod:

--- a/localEnv/Dockerfile
+++ b/localEnv/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     tar \
     gzip \
+    docker.io \
     software-properties-common \
     wget \
     tzdata
@@ -19,10 +20,12 @@ RUN wget -O- https://apt.corretto.aws/corretto.key | apt-key add - \
     && apt-get install -y java-11-amazon-corretto-jdk
 
 RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list \
-    && curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x99E82A75642AC823" | apt-key add - \
-    && apt-get update && apt-get install -y sbt
+    && curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x99E82A75642AC823" | apt-key add -
+
+RUN apt-get update && apt-get install -y sbt
 
 WORKDIR /app
+
 COPY . .
 
 RUN sbt compile stage

--- a/localEnv/docker-compose.yml
+++ b/localEnv/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.9'
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: localEnv/Dockerfile
+    ports:
+      - "9010:9000"
+    depends_on:
+      - db
+    environment:
+      DB_URL: "jdbc:mysql://db:3306/exam_manager"
+      DB_USER: "your_username"
+      DB_PASSWORD: "your_password"
+    command: sbt run
+
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+      MYSQL_DATABASE: exam_manager
+      MYSQL_USER: your_username
+      MYSQL_PASSWORD: your_password
+    ports:
+      - "3310:3306"
+    volumes:
+      - exam_manager_db_data_dev:/var/lib/mysql
+
+volumes:
+  exam_manager_db_data_dev:


### PR DESCRIPTION
# What I did
- Separated the application into three distinct containers for different purposes:
　- Development Container for code writing and editing, optimized for VS Code integration.
　- Application Development Container for testing and running the application locally during development.
　- Production Container configured specifically for deployment in production environments.
- Updated each container’s Dockerfile to include only necessary dependencies, aligning with each container's responsibilities.
- Configured unique port mappings for each container to avoid conflicts when running simultaneously.
- Adjusted the docker-compose.yml files and volume names to prevent data conflicts across environments.

# Why I did
- Modular Responsibilities: Dividing the containers by responsibility helps maintain a clean and modular setup. This makes each environment more manageable and optimizes performance by loading only what’s necessary.
- Avoid Port Conflicts: Ensuring unique port configurations between development and production containers prevents issues when running multiple instances on the same machine.
- Security and Efficiency: Minimizing installed packages and processes in each container improves security by reducing potential attack vectors and lowers resource consumption by avoiding unnecessary services.
- Consistency in Development: These changes support smoother transitions between development and production by ensuring the containers align with their intended environments and purposes.