### PR TITLE
[refactor] Renamed the ExamResultFieldConverter class to ExamResultFieldParser to improve proper naming.

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -22,8 +22,8 @@ import domain.evaluationPeriodProvider.impl.WeeklyEvaluationPeriodProviderImpl
 import dto.utils.dateTime.createdAtRequestConverter.impl.CreatedAtRequestConverterImpl
 import dto.utils.dateTime.updatedAtRequestConverter.impl.UpdatedAtRequestConverterImpl
 import dto.utils.dateTime.dateTimeConverter.impl.DateTimeConverterImpl
-import dto.request.examResult.jsonParser.examResultFieldConverter.impl.ExamResultFieldConverterImpl
-import dto.request.examResult.jsonParser.examResultFieldConverter.`trait`.ExamResultFieldConverter
+import dto.request.examResult.jsonParser.examResultFieldParser.impl.ExamResultFieldParserImpl
+import dto.request.examResult.jsonParser.examResultFieldParser.`trait`.ExamResultFieldParser
 import dto.utils.dateTime.createdAtRequestConverter.`trait`.CreatedAtRequestConverter
 import dto.utils.dateTime.updatedAtRequestConverter.`trait`.UpdatedAtRequestConverter
 import dto.utils.dateTime.dateTimeConverter.`trait`.DateTimeConverter
@@ -60,8 +60,8 @@ class Module(environment: Environment, configuration: Configuration)
     bind(classOf[Scheduler])
       .toProvider(classOf[SchedulerProvider])
       .asEagerSingleton()
-    bind(classOf[ExamResultFieldConverter])
-      .to(classOf[ExamResultFieldConverterImpl])
+    bind(classOf[ExamResultFieldParser])
+      .to(classOf[ExamResultFieldParserImpl])
       .asEagerSingleton()
     bind(classOf[CreatedAtRequestConverter])
       .to(classOf[CreatedAtRequestConverterImpl])

--- a/app/controllers/ExamResultController.scala
+++ b/app/controllers/ExamResultController.scala
@@ -5,7 +5,7 @@ import play.api.mvc._
 import scala.concurrent.{ ExecutionContext, Future }
 import usecases.examResult.ExamResultUsecase
 import scala.util.{ Failure, Success, Try }
-import dto.request.examResult.jsonParser.examResultFieldConverter.`trait`.ExamResultFieldConverter
+import dto.request.examResult.jsonParser.examResultFieldParser.`trait`.ExamResultFieldParser
 import play.api.libs.json.JsValue
 import views.html.defaultpages.badRequest
 import domain.examResult.valueObject._
@@ -20,14 +20,14 @@ import play.api.libs.json.Json
 class ExamResultController @Inject() (
     cc: ControllerComponents,
     examResultUsecase: ExamResultUsecase,
-    examResultFieldConverter: ExamResultFieldConverter,
+    examResultFieldParser: ExamResultFieldParser,
     examResultIdRequestDtoFactory: ExamResultIdRequestDtoFactory
 )(implicit ec: ExecutionContext)
     extends AbstractController(cc) {
 
   def saveExamResult: Action[JsValue] = Action.async(parse.json) {
     implicit request =>
-      examResultFieldConverter.convertAndValidate(request.body) match {
+      examResultFieldParser.parse(request.body) match {
         case Right(
               (
                 examId: ExamIdRequestDto,

--- a/app/dto/request/examResult/jsonParser/examResultFieldConverter/trait/ExamResultFieldConverter.scala
+++ b/app/dto/request/examResult/jsonParser/examResultFieldConverter/trait/ExamResultFieldConverter.scala
@@ -1,7 +1,0 @@
-package dto.request.examResult.jsonParser.examResultFieldConverter.`trait`
-
-import play.api.libs.json.JsValue
-
-trait ExamResultFieldConverter {
-  def convertAndValidate(json: JsValue): Either[String, Tuple]
-}

--- a/app/dto/request/examResult/jsonParser/examResultFieldParser/impl/ExamResultFieldParserImpl.scala
+++ b/app/dto/request/examResult/jsonParser/examResultFieldParser/impl/ExamResultFieldParserImpl.scala
@@ -1,4 +1,4 @@
-package dto.request.examResult.jsonParser.examResultFieldConverter.impl
+package dto.request.examResult.jsonParser.examResultFieldParser.impl
 
 import javax.inject._
 import dto.request.exam.valueObject._
@@ -6,19 +6,19 @@ import dto.request.examResult.valueObject._
 import dto.request.utils.dateTime._
 import dto.utils.dateTime.createdAtRequestConverter.`trait`.CreatedAtRequestConverter
 import dto.utils.dateTime.updatedAtRequestConverter.`trait`.UpdatedAtRequestConverter
-import dto.request.examResult.jsonParser.examResultFieldConverter.`trait`.ExamResultFieldConverter
+import dto.request.examResult.jsonParser.examResultFieldParser.`trait`.ExamResultFieldParser
 import dto.request.utils.jsonFieldParser.`trait`.JsonFieldParser
 import play.api.libs.json.JsValue
 
 @Singleton
-class ExamResultFieldConverterImpl @Inject() (
+class ExamResultFieldParserImpl @Inject() (
     examResultIdRequestDtoFactory: ExamResultIdRequestDtoFactory,
     examIdRequestDtoFactory: ExamIdRequestDtoFactory,
     studentIdRequestDtoFactory: StudentIdRequestDtoFactory,
     createdAtRequestFactory: CreatedAtRequestFactory,
     updatedAtRequestFactory: UpdatedAtRequestFactory,
     jsonFieldParser: JsonFieldParser
-) extends ExamResultFieldConverter {
+) extends ExamResultFieldParser {
 
   private def createParseList(
       requestBody: Map[String, String]
@@ -49,7 +49,7 @@ class ExamResultFieldConverterImpl @Inject() (
       .map(updatedAtRequestFactory.create)
   ).flatten
 
-  override def convertAndValidate(json: JsValue): Either[String, Tuple] =
+  override def parse(json: JsValue): Either[String, Tuple] =
     jsonFieldParser.extractFields(json, createParseList).map { parsedFields =>
       jsonFieldParser.toTuple(parsedFields)
     }

--- a/app/dto/request/examResult/jsonParser/examResultFieldParser/trait/ExamResultFieldParser.scala
+++ b/app/dto/request/examResult/jsonParser/examResultFieldParser/trait/ExamResultFieldParser.scala
@@ -1,0 +1,7 @@
+package dto.request.examResult.jsonParser.examResultFieldParser.`trait`
+
+import play.api.libs.json.JsValue
+
+trait ExamResultFieldParser {
+  def parse(json: JsValue): Either[String, Tuple]
+}

--- a/test/integration/controllers/ExamResultControllerIntegrationSpec.scala
+++ b/test/integration/controllers/ExamResultControllerIntegrationSpec.scala
@@ -39,7 +39,6 @@ import infrastructure.libs.UlidGeneratorImpl
 import infrastructure.db.repositories.{ ExamRepositoryImplOnDb, ExamResultRepositoryImplOnDb }
 import infrastructure.db.DatabaseConfig
 import infrastructure.db.table.ExamResultTable
-import dto.request.examResult.jsonParser.examResultFieldConverter.`trait`.ExamResultFieldConverter
 import dto.response.examResult.entity.ExamResultResponseDto
 import utils.SystemClock
 import utils.UlidGenerator

--- a/test/unit/controllers/ExamResultControllerSpec.scala
+++ b/test/unit/controllers/ExamResultControllerSpec.scala
@@ -21,7 +21,7 @@ import domain.utils.dateTime.{ CreatedAt, UpdatedAt }
 import domain.examResult.entity.ExamResult
 import usecases.examResult.ExamResultUsecase
 import dto.response.examResult.entity.ExamResultResponseDto
-import dto.request.examResult.jsonParser.examResultFieldConverter.`trait`.ExamResultFieldConverter
+import dto.request.examResult.jsonParser.examResultFieldParser.`trait`.ExamResultFieldParser
 import utils.CustomPatience
 
 import scala.concurrent.Future
@@ -41,8 +41,8 @@ class ExamResultControllerSpec
     with CustomPatience {
 
   val mockUsecase: ExamResultUsecase = mock(classOf[ExamResultUsecase])
-  val mockExamResultFieldConverter: ExamResultFieldConverter = mock(
-    classOf[ExamResultFieldConverter]
+  val mockexamResultFieldParser: ExamResultFieldParser = mock(
+    classOf[ExamResultFieldParser]
   )
   val mockExamResultIdRequestDtoFactory: ExamResultIdRequestDtoFactory = mock(
     classOf[ExamResultIdRequestDtoFactory]
@@ -51,7 +51,7 @@ class ExamResultControllerSpec
   override def fakeApplication() = new GuiceApplicationBuilder()
     .overrides(
       bind[ExamResultUsecase].toInstance(mockUsecase),
-      bind[ExamResultFieldConverter].toInstance(mockExamResultFieldConverter),
+      bind[ExamResultFieldParser].toInstance(mockexamResultFieldParser),
       bind[ExamResultIdRequestDtoFactory]
         .toInstance(mockExamResultIdRequestDtoFactory)
     )
@@ -86,7 +86,7 @@ class ExamResultControllerSpec
         "studentId" -> "student-id"
       )
 
-      when(mockExamResultFieldConverter.convertAndValidate(any[JsValue]))
+      when(mockexamResultFieldParser.parse(any[JsValue]))
         .thenReturn(
           Right(
             (
@@ -118,7 +118,7 @@ class ExamResultControllerSpec
         "studentId" -> "student-id"
       )
 
-      when(mockExamResultFieldConverter.convertAndValidate(any[JsValue]))
+      when(mockexamResultFieldParser.parse(any[JsValue]))
         .thenReturn(Left("Invalid parameters"))
 
       val request = FakeRequest(POST, "/exam-result")


### PR DESCRIPTION
# What I did
- Renamed the class from `ExamResultFieldConverter` to `ExamResultFieldParser` to better reflect its responsibility in parsing JSON input to DTOs.

# Why I did it
- The class processes JSON input and produces appropriate DTOs, which aligns more with the behavior of a parser rather than a converter. The new name provides better clarity and consistency.