### PR TITLE
[chore] Update docker-compose commands to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you are not using VSCode, follow these steps:
 2. Clone the repository and navigate to the root directory.
 3. Run the following command to build and run the development container:
     ~~~bash
-    docker-compose -f .devcontainer/docker-compose.yml up --build
+    docker compose -f .devcontainer/docker-compose.yml up --build
     ~~~
 4. You can use any IDE or editor to write and edit the code. To connect to the container terminal, use:
     ~~~bash


### PR DESCRIPTION
# What I did
- Updated all places of the deprecated `docker-compose` command to the modern `docker compose` command.

# Why I did it
- The `docker-compose` command is deprecated, and `docker compose` is now the recommended approach for running Docker. This ensures compatibility with newer Docker versions and avoids potential issues in the future.